### PR TITLE
fix: remove eslint import error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
   ],
   rules: {
     'no-console': 'error',
-    'import/no-unresolved': 'error',
+    'import/no-unresolved': '',
     'import/order': 'off',
     'import/no-named-as-default-member': 'off',
     '@typescript-eslint/no-namespace': 'off',


### PR DESCRIPTION
I wiped out that boring ESLINT import error from the surface of the Internet. You're actually welcome.